### PR TITLE
Add support for kernel v7.0

### DIFF
--- a/patch7.0
+++ b/patch7.0
@@ -1,0 +1,143 @@
+diff -up orig/asus-nb-wmi.c new/asus-nb-wmi.c
+--- orig/asus-nb-wmi.c	2026-05-03 05:56:49.936736855 +0200
++++ new/asus-nb-wmi.c	2026-05-03 05:56:49.939560201 +0200
+@@ -609,6 +609,7 @@ static const struct key_entry asus_nb_wm
+ 	{ KE_KEY, 0x65, { KEY_SWITCHVIDEOMODE } }, /* SDSP LCD + TV */
+ 	{ KE_KEY, 0x66, { KEY_SWITCHVIDEOMODE } }, /* SDSP CRT + TV */
+ 	{ KE_KEY, 0x67, { KEY_SWITCHVIDEOMODE } }, /* SDSP LCD + CRT + TV */
++    { KE_KEY, 0x6A, { KEY_F16 } }, /* Toggle ScreenPad key */
+ 	{ KE_KEY, 0x6B, { KEY_TOUCHPAD_TOGGLE } },
+ 	{ KE_IGNORE, 0x6E, },  /* Low Battery notification */
+ 	{ KE_KEY, 0x71, { KEY_F13 } }, /* General-purpose button */
+@@ -634,6 +635,7 @@ static const struct key_entry asus_nb_wm
+ 	{ KE_KEY, 0x95, { KEY_MEDIA } },
+ 	{ KE_KEY, 0x99, { KEY_PHONE } }, /* Conflicts with fan mode switch */
+ 	{ KE_KEY, 0X9D, { KEY_FN_F } },
++	{ KE_KEY, 0x9C, { KEY_F15 } }, /* Zenbook Duo Swap Windows */
+ 	{ KE_KEY, 0xA0, { KEY_SWITCHVIDEOMODE } }, /* SDSP HDMI only */
+ 	{ KE_KEY, 0xA1, { KEY_SWITCHVIDEOMODE } }, /* SDSP LCD + HDMI */
+ 	{ KE_KEY, 0xA2, { KEY_SWITCHVIDEOMODE } }, /* SDSP CRT + HDMI */
+diff -up orig/asus-wmi.c new/asus-wmi.c
+--- orig/asus-wmi.c	2026-05-03 05:56:49.936854234 +0200
++++ new/asus-wmi.c	2026-05-03 05:58:41.579982195 +0200
+@@ -261,6 +261,8 @@ struct asus_wmi {
+ 	bool kbd_led_registered;
+ 	struct led_classdev lightbar_led;
+ 	int lightbar_led_wk;
++	struct led_classdev screenpad_led;
++	int screenpad_led_wk;
+ 	struct led_classdev micmute_led;
+ 	struct led_classdev camera_led;
+ 	struct workqueue_struct *led_workqueue;
+@@ -268,6 +270,7 @@ struct asus_wmi {
+ 	struct work_struct wlan_led_work;
+ 	struct work_struct lightbar_led_work;
+ 	struct work_struct kbd_led_work;
++	struct work_struct screenpad_led_work;
+ 
+ 	struct asus_rfkill wlan;
+ 	struct asus_rfkill bluetooth;
+@@ -2001,6 +2004,74 @@ static int camera_led_set(struct led_cla
+ 	return err < 0 ? err : 0;
+ }
+ 
++static int screenpad_led_read(struct asus_wmi *asus, int *level)
++{
++	int value, retval;
++	retval = asus_wmi_get_devstate(asus, ASUS_WMI_DEVID_SCREENPAD_POWER, &value);
++	if (retval == 0 && (value & 0x21) != 0)
++	{
++		// screen is activated, so read backlight
++		retval = asus_wmi_get_devstate(asus, ASUS_WMI_DEVID_SCREENPAD_LIGHT, &value);
++		if (retval == 0)
++		{
++			*level = value & ASUS_WMI_DSTS_BRIGHTNESS_MASK;
++		}
++	}
++	else
++	{
++		*level = 0;
++	}
++
++	if (retval < 0)
++		return retval;
++	return 0;
++}
++
++static void screenpad_led_update(struct work_struct *work)
++{
++	struct asus_wmi *asus;
++	int ctrl_param;
++
++	asus = container_of(work, struct asus_wmi, screenpad_led_work);
++
++	ctrl_param = asus->screenpad_led_wk;
++	if (ctrl_param == 0x00)
++	{
++		// turn off screen
++		asus_wmi_set_devstate(ASUS_WMI_DEVID_SCREENPAD_POWER, ctrl_param, NULL);
++	}
++	else
++	{
++		// set backlight (also turns on screen if is off)
++		asus_wmi_set_devstate(ASUS_WMI_DEVID_SCREENPAD_LIGHT, ctrl_param, NULL);
++	}
++}
++
++static void screenpad_led_set(struct led_classdev *led_cdev,
++			     enum led_brightness value)
++{
++	struct asus_wmi *asus;
++
++	asus = container_of(led_cdev, struct asus_wmi, screenpad_led);
++
++	asus->screenpad_led_wk = value;
++	queue_work(asus->led_workqueue, &asus->screenpad_led_work);
++}
++
++static enum led_brightness screenpad_led_get(struct led_classdev *led_cdev)
++{
++	struct asus_wmi *asus;
++	int retval, value;
++
++	asus = container_of(led_cdev, struct asus_wmi, screenpad_led);
++
++	retval = screenpad_led_read(asus, &value);
++	if (retval < 0)
++		return retval;
++
++	return value;
++}
++
+ static void asus_wmi_led_exit(struct asus_wmi *asus)
+ {
+ 	scoped_guard(spinlock_irqsave, &asus_ref.lock)
+@@ -2010,6 +2081,7 @@ static void asus_wmi_led_exit(struct asu
+ 	led_classdev_unregister(&asus->wlan_led);
+ 	led_classdev_unregister(&asus->lightbar_led);
+ 	led_classdev_unregister(&asus->micmute_led);
++	led_classdev_unregister(&asus->screenpad_led);
+ 	led_classdev_unregister(&asus->camera_led);
+ 
+ 	if (asus->led_workqueue)
+@@ -2129,6 +2201,20 @@ static int asus_wmi_led_init(struct asus
+ 			goto error;
+ 	}
+ 
++	if (asus_wmi_dev_is_present(asus, ASUS_WMI_DEVID_SCREENPAD_POWER)
++		&& !screenpad_led_read(asus, &led_val)) {
++		asus->screenpad_led_wk = led_val;
++		INIT_WORK(&asus->screenpad_led_work, screenpad_led_update);
++
++		asus->screenpad_led.name = "asus::screenpad";
++		asus->screenpad_led.brightness_set = screenpad_led_set;
++		asus->screenpad_led.brightness_get = screenpad_led_get;
++		asus->screenpad_led.max_brightness = 0xff;
++
++		rv = led_classdev_register(&asus->platform_device->dev,
++					   &asus->screenpad_led);
++	}
++
+ error:
+ 	if (rv)
+ 		asus_wmi_led_exit(asus);

--- a/prepare-for-current-kernel.sh
+++ b/prepare-for-current-kernel.sh
@@ -19,8 +19,11 @@ then
 elif { echo $VERSION ; echo "6.18" ; } | sort -V -c 2>/dev/null
 then
   PATCHFILE="patch6.17"
-else
+elif { echo $VERSION ; echo "6.99" ; } | sort -V -c 2>/dev/null
+then
   PATCHFILE="patch6.19"
+else
+  PATCHFILE="patch7.0"
 fi
 
 echo "Using: $PATCHFILE - version: $VERSION"


### PR DESCRIPTION
Slight asus_wmi struct changes in `c545a70dd2a1211c33de3a09102691145acc5b35`, requiring a new patch.
The script compares against 6.99 to allow for backports, should any occur.
Tested on version 7.0.3-arch1-1
